### PR TITLE
Misc fixes

### DIFF
--- a/src/cleanercs2.cpp
+++ b/src/cleanercs2.cpp
@@ -26,6 +26,7 @@
 #include <fstream>
 #include <filesystem>
 #include <vector>
+#include <mutex>
 
 // bruh
 #undef POSIX
@@ -51,6 +52,7 @@ LogDirect_t g_pLogDirect = nullptr;
 funchook_t* g_pHook = nullptr;
 
 std::vector<re2::RE2*> g_RegexList;
+std::mutex g_RegexMutex;
 
 int Detour_LogDirect(void* loggingSystem, int channel, int severity, LeafCodeInfo_t* leafCode, char const* str, va_list* args)
 {
@@ -64,10 +66,13 @@ int Detour_LogDirect(void* loggingSystem, int channel, int severity, LeafCodeInf
 		va_end(args2);
 	}
 
-	for (auto& regex : g_RegexList)
 	{
-		if (RE2::FullMatch(args ? buffer : str, *regex))
-			return 0;
+		std::lock_guard<std::mutex> lock(g_RegexMutex);
+		for (auto& regex : g_RegexList)
+		{
+			if (RE2::FullMatch(args ? buffer : str, *regex))
+				return 0;
+		}
 	}
 
 	return g_pLogDirect(loggingSystem, channel, severity, leafCode, str, args);
@@ -100,6 +105,8 @@ bool SetupHook()
 
 void LoadConfig()
 {
+	std::lock_guard<std::mutex> lock(g_RegexMutex);
+
 	for(auto& regex : g_RegexList)
 		delete regex;
 
@@ -193,6 +200,8 @@ bool CleanerPlugin::Unload(char *error, size_t maxlen)
 		funchook_destroy(g_pHook);
 		g_pHook = nullptr;
 	}
+
+	std::lock_guard<std::mutex> lock(g_RegexMutex);
 
 	for (auto& regex : g_RegexList)
 		delete regex;

--- a/src/cleanercs2.cpp
+++ b/src/cleanercs2.cpp
@@ -80,7 +80,7 @@ int Detour_LogDirect(void* loggingSystem, int channel, int severity, LeafCodeInf
 
 bool SetupHook()
 {
-	auto serverModule = new CModule(ROOTBIN, "tier0");
+	CModule serverModule(ROOTBIN, "tier0");
 
 	int err;
 #ifdef WIN32
@@ -88,7 +88,7 @@ bool SetupHook()
 #else
 	const byte sig[] = "\x55\x89\xD0\x49\x89\xFA\x89\xF7\x48\x89\xE5";
 #endif
-	g_pLogDirect = (LogDirect_t)serverModule->FindSignature((byte*)sig, sizeof(sig) - 1, err);
+	g_pLogDirect = (LogDirect_t)serverModule.FindSignature((byte*)sig, sizeof(sig) - 1, err);
 
 	if (err)
 	{

--- a/src/cleanercs2.cpp
+++ b/src/cleanercs2.cpp
@@ -209,7 +209,7 @@ bool CleanerPlugin::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen,
 	g_SMAPI->AddListener( this, this );
 
 	g_pCVar = icvar;
-	ConVar_Register( FCVAR_RELEASE | FCVAR_CLIENT_CAN_EXECUTE | FCVAR_GAMEDLL );
+	META_CONVAR_REGISTER( FCVAR_RELEASE | FCVAR_CLIENT_CAN_EXECUTE | FCVAR_GAMEDLL );
 
 	LoadConfig();
 

--- a/src/cleanercs2.cpp
+++ b/src/cleanercs2.cpp
@@ -126,14 +126,14 @@ void LoadConfig()
 		std::string line;
 		while (std::getline(cfgFile, line))
 		{
-			if (line[0] == '/' && line[1] == '/')
-				continue;
+			// allow CRLF on linux
+			line.erase(std::remove(line.begin(), line.end(), '\r'), line.end());
 
 			if (line.empty())
 				continue;
 
-			// allow CRLF on linux
-			line.erase(std::remove(line.begin(), line.end(), '\r'), line.end());
+			if (line[0] == '/' && line[1] == '/')
+				continue;
 
 			META_CONPRINTF("Registering regex: %s\n", line.c_str());
 

--- a/src/cleanercs2.cpp
+++ b/src/cleanercs2.cpp
@@ -97,8 +97,32 @@ bool SetupHook()
 	}
 
 	g_pHook = funchook_create();
-	funchook_prepare(g_pHook, (void**)&g_pLogDirect, (void*)Detour_LogDirect);
-	funchook_install(g_pHook, 0);
+
+	if (!g_pHook)
+	{
+		META_CONPRINTF("[CleanerCS2] Failed to create hook\n");
+		return false;
+	}
+
+	int hookErr = funchook_prepare(g_pHook, (void**)&g_pLogDirect, (void*)Detour_LogDirect);
+
+	if (hookErr != FUNCHOOK_ERROR_SUCCESS)
+	{
+		META_CONPRINTF("[CleanerCS2] Failed to prepare hook: %s\n", funchook_error_message(g_pHook));
+		funchook_destroy(g_pHook);
+		g_pHook = nullptr;
+		return false;
+	}
+
+	hookErr = funchook_install(g_pHook, 0);
+
+	if (hookErr != FUNCHOOK_ERROR_SUCCESS)
+	{
+		META_CONPRINTF("[CleanerCS2] Failed to install hook: %s\n", funchook_error_message(g_pHook));
+		funchook_destroy(g_pHook);
+		g_pHook = nullptr;
+		return false;
+	}
 
 	return true;
 }

--- a/src/cleanercs2.cpp
+++ b/src/cleanercs2.cpp
@@ -91,7 +91,7 @@ bool SetupHook()
 		return false;
 	}
 
-	auto g_pHook = funchook_create();
+	g_pHook = funchook_create();
 	funchook_prepare(g_pHook, (void**)&g_pLogDirect, (void*)Detour_LogDirect);
 	funchook_install(g_pHook, 0);
 
@@ -187,17 +187,17 @@ bool CleanerPlugin::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen,
 
 bool CleanerPlugin::Unload(char *error, size_t maxlen)
 {
-	for (auto& regex : g_RegexList)
-		delete regex;
-
-	g_RegexList.clear();
-
 	if (g_pHook)
 	{
 		funchook_uninstall(g_pHook, 0);
 		funchook_destroy(g_pHook);
 		g_pHook = nullptr;
 	}
+
+	for (auto& regex : g_RegexList)
+		delete regex;
+
+	g_RegexList.clear();
 
 	return true;
 }

--- a/src/cleanercs2.cpp
+++ b/src/cleanercs2.cpp
@@ -27,6 +27,7 @@
 #include <filesystem>
 #include <vector>
 #include <mutex>
+#include <shared_mutex>
 
 // bruh
 #undef POSIX
@@ -52,7 +53,7 @@ LogDirect_t g_pLogDirect = nullptr;
 funchook_t* g_pHook = nullptr;
 
 std::vector<re2::RE2*> g_RegexList;
-std::mutex g_RegexMutex;
+std::shared_mutex g_RegexMutex;
 
 int Detour_LogDirect(void* loggingSystem, int channel, int severity, LeafCodeInfo_t* leafCode, char const* str, va_list* args)
 {
@@ -67,7 +68,7 @@ int Detour_LogDirect(void* loggingSystem, int channel, int severity, LeafCodeInf
 	}
 
 	{
-		std::lock_guard<std::mutex> lock(g_RegexMutex);
+		std::shared_lock<std::shared_mutex> lock(g_RegexMutex);
 		for (auto& regex : g_RegexList)
 		{
 			if (RE2::FullMatch(args ? buffer : str, *regex))
@@ -180,7 +181,7 @@ void LoadConfig()
 
 	std::vector<re2::RE2*> old;
 	{
-		std::lock_guard<std::mutex> lock(g_RegexMutex);
+		std::unique_lock<std::shared_mutex> lock(g_RegexMutex);
 		old.swap(g_RegexList);
 		g_RegexList.swap(fresh);
 	}
@@ -230,7 +231,7 @@ bool CleanerPlugin::Unload(char *error, size_t maxlen)
 		g_pHook = nullptr;
 	}
 
-	std::lock_guard<std::mutex> lock(g_RegexMutex);
+	std::unique_lock<std::shared_mutex> lock(g_RegexMutex);
 
 	for (auto& regex : g_RegexList)
 		delete regex;

--- a/src/cleanercs2.cpp
+++ b/src/cleanercs2.cpp
@@ -105,12 +105,7 @@ bool SetupHook()
 
 void LoadConfig()
 {
-	std::lock_guard<std::mutex> lock(g_RegexMutex);
-
-	for(auto& regex : g_RegexList)
-		delete regex;
-
-	g_RegexList.clear();
+	std::vector<re2::RE2*> fresh;
 
 	CBufferStringGrowable<MAX_PATH> gameDir;
 	engine->GetGameDir(gameDir);
@@ -148,7 +143,7 @@ void LoadConfig()
 			RE2* re = new RE2(line, options);
 
 			if (re->ok())
-				g_RegexList.push_back(re);
+				fresh.push_back(re);
 			else
 				META_CONPRINTF("[CleanerCS2] Failed to parse regex: '%s': %s\n", line.c_str(), re->error().c_str());
 		}
@@ -158,6 +153,16 @@ void LoadConfig()
 	{
 		META_CONPRINTF("[CleanerCS2] Failed to open config file\n");
 	}
+
+	std::vector<re2::RE2*> old;
+	{
+		std::lock_guard<std::mutex> lock(g_RegexMutex);
+		old.swap(g_RegexList);
+		g_RegexList.swap(fresh);
+	}
+
+	for (auto& regex : old)
+		delete regex;
 }
 
 CON_COMMAND_F(conclear_reload, "Reloads the cleaner config", FCVAR_SPONLY | FCVAR_LINKED_CONCOMMAND)


### PR DESCRIPTION
- fix `g_pHook` always being false on unload
- reversed unload order for more consistent outcome (along with mutex)
- thread safety didn't exist so I added some, this fixes cfg reload and plugin unload causing crashes in worst case scenarios
- fixed CRLF being registered as empty regex
- CModule heap allocation leak
- added handling on startup to not crash on failed hooks

If you think any of this is unnecessary, was intentionally left or should be a separate pr (or you can just cherrypick / commit them yourself) then let me know

only the unload crashes were encountered by me, but I thought I would look at it more while I was already there teehee

utils/ would probably be worth updating from upstream meaning cs2fixes as well

edit: change cvar registration to use metamod macro so it gets unregistered on unload