### PR TITLE
Backport fixes to module/platform from upstream cs2fixes, misc cleanup

### DIFF
--- a/src/cleanercs2.cpp
+++ b/src/cleanercs2.cpp
@@ -1,7 +1,7 @@
 /**
  * =============================================================================
  * CleanerCS2
- * Copyright (C) 2024 Poggu
+ * Copyright (C) 2024-2026 Poggu
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/src/cleanercs2.h
+++ b/src/cleanercs2.h
@@ -1,7 +1,7 @@
 /**
  * =============================================================================
  * CleanerCS2
- * Copyright (C) 2024 Poggu
+ * Copyright (C) 2024-2026 Poggu
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/src/utils/module.h
+++ b/src/utils/module.h
@@ -74,7 +74,7 @@ public:
 		for (size_t i = 0; i < m_size; i++)
 		{
 			size_t Matches = 0;
-			while (*(pMemory + i + Matches) == pData[Matches] || pData[Matches] == '\x2A')
+			while (i + Matches < m_size && (*(pMemory + i + Matches) == pData[Matches] || pData[Matches] == '\x2A'))
 			{
 				Matches++;
 				if (Matches == iSigLength)

--- a/src/utils/module.h
+++ b/src/utils/module.h
@@ -86,6 +86,7 @@ public:
 					}
 
 					return_addr = (void *)(pMemory + i);
+					break;
 				}
 			}
 		}

--- a/src/utils/module.h
+++ b/src/utils/module.h
@@ -1,7 +1,7 @@
 /**
  * =============================================================================
  * CS2Fixes
- * Copyright (C) 2023 Source2ZE
+ * Copyright (C) 2023-2026 Source2ZE
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/src/utils/plat.h
+++ b/src/utils/plat.h
@@ -1,7 +1,7 @@
 /**
  * =============================================================================
  * CS2Fixes
- * Copyright (C) 2023 Source2ZE
+ * Copyright (C) 2023-2026 Source2ZE
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/src/utils/plat_unix.cpp
+++ b/src/utils/plat_unix.cpp
@@ -1,7 +1,7 @@
 /**
  * =============================================================================
  * CS2Fixes
- * Copyright (C) 2023 Source2ZE
+ * Copyright (C) 2023-2026 Source2ZE
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/src/utils/plat_unix.cpp
+++ b/src/utils/plat_unix.cpp
@@ -102,7 +102,7 @@ int GetModuleInformation(HINSTANCE hModule, void** base, size_t* length)
 		Elf64_Phdr& hdr = phdr[i];
 
 		/* We only really care about the segment with executable code */
-		if (hdr.p_type == PT_LOAD && hdr.p_flags == (PF_X | PF_R))
+		if (hdr.p_type == PT_LOAD && (hdr.p_flags & PF_X))
 		{
 			/* From glibc, elf/dl-load.c:
 			 * c->mapend = ((ph->p_vaddr + ph->p_filesz + GLRO(dl_pagesize) - 1)

--- a/src/utils/plat_unix.cpp
+++ b/src/utils/plat_unix.cpp
@@ -113,7 +113,7 @@ int GetModuleInformation(HINSTANCE hModule, void** base, size_t* length)
 			 */
 			//lib.memorySize = PAGE_ALIGN_UP(hdr.p_filesz);
 			*length = PAGE_ALIGN_UP(hdr.p_filesz);
-			*base = (void*)(baseAddr + hdr.p_paddr);
+			*base = (void*)(baseAddr + hdr.p_vaddr);
 
 			break;
 		}

--- a/src/utils/plat_win.cpp
+++ b/src/utils/plat_win.cpp
@@ -1,7 +1,7 @@
 /**
  * =============================================================================
  * CS2Fixes
- * Copyright (C) 2023 Source2ZE
+ * Copyright (C) 2023-2026 Source2ZE
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/xmake.lua
+++ b/xmake.lua
@@ -21,14 +21,12 @@ target("CleanerCS2-Xmake")
     if is_plat("windows") then
         add_links({
             SDK_PATH.."/lib/public/win64/tier0.lib",
-            SDK_PATH.."/lib/public/win64/tier1.lib",
             SDK_PATH.."/lib/public/win64/interfaces.lib",
             SDK_PATH.."/lib/public/win64/mathlib.lib",
         })
     else
         add_links({
             SDK_PATH.."/lib/linux64/libtier0.so",
-            SDK_PATH.."/lib/linux64/tier1.a",
             SDK_PATH.."/lib/linux64/interfaces.a",
             SDK_PATH.."/lib/linux64/mathlib.a",
         })


### PR DESCRIPTION
- Removed tier1 from links on compile (it no longer exists on sdk)
- Updated copyright year (yeah this is kinda dumb but it bothered me)
- Backported a few fixes from upstream cs2fixes, 2 OOB reads, never ending loop, messed up matching on executable code, `p_paddr` -> `p_vaddr`